### PR TITLE
Added support for User Switching plugin

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -27,7 +27,7 @@ class Debug_Bar {
 	}
 
 	function init() {
-		if ( ! is_super_admin() || ! is_admin_bar_showing() || $this->is_wp_login() )
+		if ( ! $this->is_super_admin() || ! is_admin_bar_showing() || $this->is_wp_login() )
 			return;
 
 		add_action( 'admin_bar_menu',               array( &$this, 'admin_bar_menu' ), 1000 );
@@ -50,7 +50,7 @@ class Debug_Bar {
 	}
 
 	function init_ajax() {
-		if ( ! is_super_admin() )
+		if ( ! $this->is_super_admin() )
 			return;
 
 		$this->requirements();
@@ -110,6 +110,20 @@ class Debug_Bar {
 			$usage = memory_get_usage();
 		}
 		return $usage;
+	}
+
+	// same as is_super_admin, but also adds support for user-switching plugin
+	function is_super_admin() {
+		$user_id = get_current_user_id();
+
+		if ( defined( 'OLDUSER_COOKIE' ) ) {
+			if ( isset( $_COOKIE[OLDUSER_COOKIE] ) ) {
+				if( $original_id = wp_validate_auth_cookie( $_COOKIE[OLDUSER_COOKIE], 'old_user' ) )
+					$user_id = $original_id;
+			}
+		}
+
+		return is_super_admin( $user_id );
 	}
 
 	function admin_bar_menu() {


### PR DESCRIPTION
I'm developing quite a large multisite project right now and for that I needed to view debug information when switching to another user (http://wordpress.org/extend/plugins/user-switching/). By default, Debug Bar only allows super admins to view debug information, so I added a version of `is_super_admin()` that also authenticates the auth cookie of the original user and if that user is a super admin, then debug information can be viewed as well.

I tested it only in v0.8, because the current 0.9-alpha didn't work for me. Would be great if this could be added.
