### PR TITLE
Fixed constructor depreciation

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -20,7 +20,7 @@
 class Debug_Bar {
 	var $panels = array();
 
-	function Debug_Bar() {
+	function __construct() {
 		if ( defined('DOING_AJAX') && DOING_AJAX )
 			add_action( 'admin_init', array( &$this, 'init_ajax' ) );
 		add_action( 'admin_bar_init', array( &$this, 'init' ) );

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -4,7 +4,7 @@ class Debug_Bar_Panel {
 	var $_title = '';
 	var $_visible = true;
 
-	function Debug_Bar_Panel( $title='' ) {
+	function __construct( $title='' ) {
 		$this->title( $title );
 
 		if ( $this->init() === false ) {


### PR DESCRIPTION
php 7 has added deprecation warnings for same-name constructor functions. changed to __construct()
